### PR TITLE
後編 第1章 自分の面談日程の表示・登録・編集・削除機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem 'devise-bootstrap-views'
 gem 'devise-i18n'
 gem 'devise-i18n-views'
 gem 'simple_form'
+gem 'data-confirm-modal'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem 'jquery-rails'
 gem 'devise-bootstrap-views'
 gem 'devise-i18n'
 gem 'devise-i18n-views'
+gem 'simple_form'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,6 +148,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    simple_form (4.0.1)
+      actionpack (>= 5.0)
+      activemodel (>= 5.0)
     spring (2.0.2)
       activesupport (>= 4.2)
     spring-watcher-listen (2.0.1)
@@ -196,6 +199,7 @@ DEPENDENCIES
   puma (~> 3.7)
   rails (~> 5.1.4)
   sass-rails (~> 5.0)
+  simple_form
   spring
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,6 +58,8 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.0.5)
     crass (1.0.4)
+    data-confirm-modal (1.6.2)
+      railties (>= 3.0)
     devise (4.4.3)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -188,6 +190,7 @@ DEPENDENCIES
   bootstrap (~> 4.1.1)
   byebug
   coffee-rails (~> 4.2)
+  data-confirm-modal
   devise
   devise-bootstrap-views
   devise-i18n

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,5 +16,6 @@
 //= require rails-ujs
 //= require popper
 //= require bootstrap-sprockets
+//= require data-confirm-modal
 //= require_tree .
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -23,3 +23,11 @@
 .table {
   text-align: center;
 }
+
+.navbar {
+  font-weight: bold;
+}
+
+.nav-item {
+  padding: 10px;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -17,5 +17,9 @@
 .container {
   width: 80%;
   margin: 5% auto;
-  max-width: 500px;
+  max-width: 600px;
+}
+
+.table {
+  text-align: center;
 }

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -4,7 +4,7 @@ class InterviewsController < ApplicationController
   # GET /interviews
   # GET /interviews.json
   def index
-    @interviews = Interview.all
+    @interviews = current_user.interviews
   end
 
   # GET /interviews/1

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -1,0 +1,74 @@
+class InterviewsController < ApplicationController
+  before_action :set_interview, only: [:show, :edit, :update, :destroy]
+
+  # GET /interviews
+  # GET /interviews.json
+  def index
+    @interviews = Interview.all
+  end
+
+  # GET /interviews/1
+  # GET /interviews/1.json
+  def show
+  end
+
+  # GET /interviews/new
+  def new
+    @interview = Interview.new
+  end
+
+  # GET /interviews/1/edit
+  def edit
+  end
+
+  # POST /interviews
+  # POST /interviews.json
+  def create
+    @interview = Interview.new(interview_params)
+
+    respond_to do |format|
+      if @interview.save
+        format.html { redirect_to @interview, notice: 'Interview was successfully created.' }
+        format.json { render :show, status: :created, location: @interview }
+      else
+        format.html { render :new }
+        format.json { render json: @interview.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /interviews/1
+  # PATCH/PUT /interviews/1.json
+  def update
+    respond_to do |format|
+      if @interview.update(interview_params)
+        format.html { redirect_to @interview, notice: 'Interview was successfully updated.' }
+        format.json { render :show, status: :ok, location: @interview }
+      else
+        format.html { render :edit }
+        format.json { render json: @interview.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /interviews/1
+  # DELETE /interviews/1.json
+  def destroy
+    @interview.destroy
+    respond_to do |format|
+      format.html { redirect_to interviews_url, notice: 'Interview was successfully destroyed.' }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_interview
+      @interview = Interview.find(params[:id])
+    end
+
+    # Never trust parameters from the scary internet, only allow the white list through.
+    def interview_params
+      params.fetch(:interview, {})
+    end
+end

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -2,13 +2,11 @@ class InterviewsController < ApplicationController
   before_action :set_interview, only: [:show, :edit, :update, :destroy]
 
   # GET /interviews
-  # GET /interviews.json
   def index
     @interviews = current_user.interviews
   end
 
   # GET /interviews/1
-  # GET /interviews/1.json
   def show
   end
 
@@ -22,23 +20,18 @@ class InterviewsController < ApplicationController
   end
 
   # POST /interviews
-  # POST /interviews.json
   def create
     @interview = Interview.new(interview_params)
-
-    respond_to do |format|
-      if @interview.save
-        format.html { redirect_to @interview, notice: 'Interview was successfully created.' }
-        format.json { render :show, status: :created, location: @interview }
-      else
-        format.html { render :new }
-        format.json { render json: @interview.errors, status: :unprocessable_entity }
-      end
+    @interview.user = current_user
+    if @interview.save
+      redirect_to @interview, notice: '面談日程が作成されました。'
+    else
+      render :new
     end
   end
 
+
   # PATCH/PUT /interviews/1
-  # PATCH/PUT /interviews/1.json
   def update
     respond_to do |format|
       if @interview.update(interview_params)
@@ -52,7 +45,6 @@ class InterviewsController < ApplicationController
   end
 
   # DELETE /interviews/1
-  # DELETE /interviews/1.json
   def destroy
     @interview.destroy
     respond_to do |format|
@@ -62,13 +54,13 @@ class InterviewsController < ApplicationController
   end
 
   private
-    # Use callbacks to share common setup or constraints between actions.
-    def set_interview
-      @interview = Interview.find(params[:id])
-    end
+  # Use callbacks to share common setup or constraints between actions.
+  def set_interview
+    @interview = Interview.find(params[:id])
+  end
 
-    # Never trust parameters from the scary internet, only allow the white list through.
-    def interview_params
-      params.fetch(:interview, {})
-    end
+  # Never trust parameters from the scary internet, only allow the white list through.
+  def interview_params
+    params.require(:interview).permit(:interview_date, :approval)
+  end
 end

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -33,24 +33,17 @@ class InterviewsController < ApplicationController
 
   # PATCH/PUT /interviews/1
   def update
-    respond_to do |format|
-      if @interview.update(interview_params)
-        format.html { redirect_to @interview, notice: 'Interview was successfully updated.' }
-        format.json { render :show, status: :ok, location: @interview }
-      else
-        format.html { render :edit }
-        format.json { render json: @interview.errors, status: :unprocessable_entity }
-      end
+    if @interview.update(interview_params)
+      redirect_to @interview, notice: '面談日程が更新されました。'
+    else
+      render :edit
     end
   end
 
   # DELETE /interviews/1
   def destroy
     @interview.destroy
-    respond_to do |format|
-      format.html { redirect_to interviews_url, notice: 'Interview was successfully destroyed.' }
-      format.json { head :no_content }
-    end
+    redirect_to @interview, notice: '面談日程が削除されました。'
   end
 
   private

--- a/app/helpers/interviews_helper.rb
+++ b/app/helpers/interviews_helper.rb
@@ -1,0 +1,2 @@
+module InterviewsHelper
+end

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -1,0 +1,2 @@
+class Interview < ApplicationRecord
+end

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -1,2 +1,4 @@
 class Interview < ApplicationRecord
+  belongs_to :user
+  validates :interview_date, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,5 +3,5 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
-  has_many :interviews
+  has_many :interviews, dependent: :destroy
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,5 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
+  has_many :interviews
 end

--- a/app/views/interviews/_form.html.erb
+++ b/app/views/interviews/_form.html.erb
@@ -9,6 +9,6 @@
   </div>
 
   <div>
-    <button type="submit" class="btn btn-outline-primary">登録</button>
+    <button type="submit" class="btn btn-outline-success">更新する</button>
   </div>
 <% end %>

--- a/app/views/interviews/_form.html.erb
+++ b/app/views/interviews/_form.html.erb
@@ -3,10 +3,12 @@
   <%= f.error_notification %>
   <%= f.error_notification message: f.object.errors[:base].to_sentence if f.object.errors[:base].present? %>
 
-  <div class="form-inputs">
+  <div class="form-group">
+    <%= f.label :面接開始時間 %><br />
+    <%= f.datetime_field :interview_date, {min: Time.zone.today,max: Time.zone.today.end_of_year} %>
   </div>
 
-  <div class="form-actions">
-    <%= f.button :submit %>
+  <div>
+    <button type="submit" class="btn btn-outline-primary">登録</button>
   </div>
 <% end %>

--- a/app/views/interviews/_form.html.erb
+++ b/app/views/interviews/_form.html.erb
@@ -1,0 +1,12 @@
+
+<%= simple_form_for(@interview) do |f| %>
+  <%= f.error_notification %>
+  <%= f.error_notification message: f.object.errors[:base].to_sentence if f.object.errors[:base].present? %>
+
+  <div class="form-inputs">
+  </div>
+
+  <div class="form-actions">
+    <%= f.button :submit %>
+  </div>
+<% end %>

--- a/app/views/interviews/edit.html.erb
+++ b/app/views/interviews/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Editing Interview</h1>
+
+<%= render 'form', interview: @interview %>
+
+<%= link_to 'Show', @interview %> |
+<%= link_to 'Back', interviews_path %>

--- a/app/views/interviews/edit.html.erb
+++ b/app/views/interviews/edit.html.erb
@@ -1,5 +1,5 @@
 <div class="container">
-  <h1>面談日程編集</h1>
+  <h1>面接日程編集</h1>
 
   <%= render 'form', interview: @interview %>
   <br/>

--- a/app/views/interviews/edit.html.erb
+++ b/app/views/interviews/edit.html.erb
@@ -1,6 +1,7 @@
-<h1>Editing Interview</h1>
+<div class="container">
+  <h1>面談日程編集</h1>
 
-<%= render 'form', interview: @interview %>
-
-<%= link_to 'Show', @interview %> |
-<%= link_to 'Back', interviews_path %>
+  <%= render 'form', interview: @interview %>
+  <br/>
+  <%= link_to '戻る', interviews_path %>
+</div>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -1,0 +1,25 @@
+<p id="notice"><%= notice %></p>
+
+<h1>Interviews</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @interviews.each do |interview| %>
+      <tr>
+        <td><%= link_to 'Show', interview %></td>
+        <td><%= link_to 'Edit', edit_interview_path(interview) %></td>
+        <td><%= link_to 'Destroy', interview, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to 'New Interview', new_interview_path %>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -1,25 +1,30 @@
-<p id="notice"><%= notice %></p>
+<div class="container">
+  <p id="notice"><%= notice %></p>
 
-<h1><%= current_user.name %>さんの面談一覧</h1>
+  <h1><%= current_user.name %>さんの面接一覧</h1>
 
-<table>
-  <thead>
+  <table>
+    <thead>
     <tr>
+      <th>面接開始時間</th>
+      <th>承認状況</th>
       <th colspan="3"></th>
     </tr>
-  </thead>
+    </thead>
 
-  <tbody>
+    <tbody>
     <% @interviews.each do |interview| %>
       <tr>
-        <td><%= link_to 'Show', interview %></td>
-        <td><%= link_to 'Edit', edit_interview_path(interview) %></td>
-        <td><%= link_to 'Destroy', interview, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <td><%= interview.interview_date %></td>
+        <td><%= interview.approval %></td>
+        <td><%= link_to '編集', edit_interview_path(interview), class: "btn btn-primary" %></td>
+        <td><%= link_to '削除', interview, method: :delete, data: { confirm: '本当に削除しますか?' } ,class: "btn btn-danger" %></td>
       </tr>
     <% end %>
-  </tbody>
-</table>
+    </tbody>
+  </table>
 
-<br>
+  <br>
 
-<%= link_to '新規面談作成', new_interview_path %>
+  <%= link_to '新規面接予定', new_interview_path %>
+</div>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -26,6 +26,6 @@
 
   <br>
 
-  <%= link_to "新規面談作成", new_interview_path, class: "btn btn-outline-primary" %>
+  <%= link_to "新規面接作成", new_interview_path, class: "btn btn-outline-primary" %>
 
 <div/>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -14,7 +14,7 @@
     <tbody>
     <% @interviews.each do |interview| %>
       <tr>
-        <td><%= interview.interview_date %></td>
+        <td><%= interview.interview_date.strftime("%Y年%m月%d日 %H時%M分") %></td>
         <td><%= interview.approval %></td>
         <td><%= link_to '編集', edit_interview_path(interview), class: "btn btn-outline-primary" %></td>
         <td><%= link_to '削除', interview, method: :delete, data: { confirm: '本当に削除しますか?' ,

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -2,7 +2,7 @@
 
   <h1><%= current_user.name %>さんの面接一覧</h1>
 
-  <table>
+  <table class="table table-bordered table-hover">
     <thead>
     <tr>
       <th>面接開始時間</th>
@@ -26,5 +26,6 @@
 
   <br>
 
-  <%= link_to '新規面接予定', new_interview_path %>
-</div>
+  <%= link_to "新規面談作成", new_interview_path, class: "btn btn-outline-primary" %>
+
+<div/>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -1,6 +1,6 @@
 <p id="notice"><%= notice %></p>
 
-<h1>Interviews</h1>
+<h1><%= current_user.name %>さんの面談一覧</h1>
 
 <table>
   <thead>
@@ -22,4 +22,4 @@
 
 <br>
 
-<%= link_to 'New Interview', new_interview_path %>
+<%= link_to '新規面談作成', new_interview_path %>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -1,5 +1,4 @@
 <div class="container">
-  <p id="notice"><%= notice %></p>
 
   <h1><%= current_user.name %>さんの面接一覧</h1>
 
@@ -17,8 +16,9 @@
       <tr>
         <td><%= interview.interview_date %></td>
         <td><%= interview.approval %></td>
-        <td><%= link_to '編集', edit_interview_path(interview), class: "btn btn-primary" %></td>
-        <td><%= link_to '削除', interview, method: :delete, data: { confirm: '本当に削除しますか?' } ,class: "btn btn-danger" %></td>
+        <td><%= link_to '編集', edit_interview_path(interview), class: "btn btn-outline-primary" %></td>
+        <td><%= link_to '削除', interview, method: :delete, data: { confirm: '本当に削除しますか?' ,
+                cancel: 'やめる', commit: '削除する', title: '削除の確認'} , class: "btn btn-outline-danger" %></td>
       </tr>
     <% end %>
     </tbody>

--- a/app/views/interviews/new.html.erb
+++ b/app/views/interviews/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New Interview</h1>
+
+<%= render 'form', interview: @interview %>
+
+<%= link_to 'Back', interviews_path %>

--- a/app/views/interviews/new.html.erb
+++ b/app/views/interviews/new.html.erb
@@ -1,5 +1,5 @@
 <div class="container">
-  <h1>新規面談予定</h1>
+  <h1>新規面接予定</h1>
 
   <%= render 'form', interview: @interview %>
 </div>

--- a/app/views/interviews/new.html.erb
+++ b/app/views/interviews/new.html.erb
@@ -1,5 +1,5 @@
-<h1>New Interview</h1>
+<div class="container">
+  <h1>新規面談予定</h1>
 
-<%= render 'form', interview: @interview %>
-
-<%= link_to 'Back', interviews_path %>
+  <%= render 'form', interview: @interview %>
+</div>

--- a/app/views/interviews/show.html.erb
+++ b/app/views/interviews/show.html.erb
@@ -1,0 +1,4 @@
+<p id="notice"><%= notice %></p>
+
+<%= link_to 'Edit', edit_interview_path(@interview) %> |
+<%= link_to 'Back', interviews_path %>

--- a/app/views/interviews/show.html.erb
+++ b/app/views/interviews/show.html.erb
@@ -1,4 +1,17 @@
 <div class="container">
+  <p>
+    <strong>面談日程</strong>
+    <br/>
+    <%= @interview.interview_date %>
+  </p>
+
+  <p>
+    <strong>承認状態</strong>
+    <br/>
+    <%= @interview.approval %>
+  </p>
+
+  <br/>
   <%= link_to '面談日程編集', edit_interview_path(@interview) %> |
   <%= link_to '戻る', interviews_path %>
 </div>

--- a/app/views/interviews/show.html.erb
+++ b/app/views/interviews/show.html.erb
@@ -1,6 +1,6 @@
 <div class="container">
   <p>
-    <strong>面談日程</strong>
+    <strong>面接日程</strong>
     <br/>
     <%= @interview.interview_date %>
   </p>
@@ -12,6 +12,6 @@
   </p>
 
   <br/>
-  <%= link_to '面談日程編集', edit_interview_path(@interview) %> |
+  <%= link_to '面接日程編集', edit_interview_path(@interview) %> |
   <%= link_to '戻る', interviews_path %>
 </div>

--- a/app/views/interviews/show.html.erb
+++ b/app/views/interviews/show.html.erb
@@ -1,4 +1,4 @@
-<p id="notice"><%= notice %></p>
-
-<%= link_to 'Edit', edit_interview_path(@interview) %> |
-<%= link_to 'Back', interviews_path %>
+<div class="container">
+  <%= link_to '面談日程編集', edit_interview_path(@interview) %> |
+  <%= link_to '戻る', interviews_path %>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,6 +13,7 @@
       <a class="navbar-brand" href="/">面談日程調整</a>
         <% if user_signed_in? %>
           <%= link_to 'プロフィール', edit_user_registration_path %>
+          <%= link_to '自分の面談一覧', interviews_path %>
           <%= link_to 'ログアウト', destroy_user_session_path, method: :delete %>
         <% else %>
           <%= link_to 'ユーザー登録', new_user_registration_path %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>面談日程調整</title>
+    <title>面接日程調整</title>
     <%= csrf_meta_tags %>
 
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
@@ -10,10 +10,10 @@
 
   <body>
     <nav class="navbar navbar-expand-lg navbar-light bg-light">
-      <a class="navbar-brand" href="/">面談日程調整</a>
+      <a class="navbar-brand" href="/">面接日程調整</a>
         <% if user_signed_in? %>
           <%= link_to 'プロフィール', edit_user_registration_path %>
-          <%= link_to '自分の面談一覧', interviews_path %>
+          <%= link_to '自分の面接一覧', interviews_path %>
           <%= link_to 'ログアウト', destroy_user_session_path, method: :delete %>
         <% else %>
           <%= link_to 'ユーザー登録', new_user_registration_path %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,17 +11,31 @@
   <body>
     <nav class="navbar navbar-expand-lg navbar-light bg-light">
       <a class="navbar-brand" href="/">面接日程調整</a>
-        <% if user_signed_in? %>
-          <%= link_to 'プロフィール', edit_user_registration_path %>
-          <%= link_to '自分の面接一覧', interviews_path %>
-          <%= link_to 'ログアウト', destroy_user_session_path, method: :delete %>
-        <% else %>
-          <%= link_to 'ユーザー登録', new_user_registration_path %>
-          <%= link_to 'ログイン', new_user_session_path %>
-        <% end %>
-      <button type="button" class="navbar-toggler" data-toggle="collapse" data-target="#Navber" aria-controls="Navber" aria-expanded="false" aria-label="ナビゲーションの切替">
+      <button type="button" class="navbar-toggler" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="ナビゲーションの切替">
         <span class="navbar-toggler-icon"></span>
       </button>
+      <div class="collapse navbar-collapse" id="navbarNav">
+        <ul class="navbar-nav">
+          <% if user_signed_in? %>
+          <li class="nav-item">
+            <%= link_to 'プロフィール', edit_user_registration_path %>
+          </li>
+          <li class="nav-item">
+            <%= link_to '自分の面接一覧', interviews_path %>
+          </li>
+          <li class="nav-item">
+            <%= link_to 'ログアウト', destroy_user_session_path, method: :delete %>
+          </li>
+          <% else %>
+          <li class="nav-item">
+            <%= link_to 'ユーザー登録', new_user_registration_path %>
+          </li>
+          <li class="nav-item">
+            <%= link_to 'ログイン', new_user_session_path %>
+          </li>
+          <% end %>
+        </ul>
+      </div>
     </nav>
     <% if notice.present? %>
       <div class="alert alert-dismissable alert-success">

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -1,0 +1,182 @@
+# frozen_string_literal: true
+#
+# Uncomment this and change the path if necessary to include your own
+# components.
+# See https://github.com/plataformatec/simple_form#custom-components to know
+# more about custom components.
+# Dir[Rails.root.join('lib/components/**/*.rb')].each { |f| require f }
+#
+# Use this setup block to configure all options available in SimpleForm.
+SimpleForm.setup do |config|
+  # Wrappers are used by the form builder to generate a
+  # complete input. You can remove any component from the
+  # wrapper, change the order or even add your own to the
+  # stack. The options given below are used to wrap the
+  # whole input.
+  config.wrappers :default, class: :input,
+    hint_class: :field_with_hint, error_class: :field_with_errors, valid_class: :field_without_errors do |b|
+    ## Extensions enabled by default
+    # Any of these extensions can be disabled for a
+    # given input by passing: `f.input EXTENSION_NAME => false`.
+    # You can make any of these extensions optional by
+    # renaming `b.use` to `b.optional`.
+
+    # Determines whether to use HTML5 (:email, :url, ...)
+    # and required attributes
+    b.use :html5
+
+    # Calculates placeholders automatically from I18n
+    # You can also pass a string as f.input placeholder: "Placeholder"
+    b.use :placeholder
+
+    ## Optional extensions
+    # They are disabled unless you pass `f.input EXTENSION_NAME => true`
+    # to the input. If so, they will retrieve the values from the model
+    # if any exists. If you want to enable any of those
+    # extensions by default, you can change `b.optional` to `b.use`.
+
+    # Calculates maxlength from length validations for string inputs
+    # and/or database column lengths
+    b.optional :maxlength
+
+    # Calculate minlength from length validations for string inputs
+    b.optional :minlength
+
+    # Calculates pattern from format validations for string inputs
+    b.optional :pattern
+
+    # Calculates min and max from length validations for numeric inputs
+    b.optional :min_max
+
+    # Calculates readonly automatically from readonly attributes
+    b.optional :readonly
+
+    ## Inputs
+    # b.use :input, class: 'input', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :label_input
+    b.use :hint,  wrap_with: { tag: :span, class: :hint }
+    b.use :error, wrap_with: { tag: :span, class: :error }
+
+    ## full_messages_for
+    # If you want to display the full error message for the attribute, you can
+    # use the component :full_error, like:
+    #
+    # b.use :full_error, wrap_with: { tag: :span, class: :error }
+  end
+
+  # The default wrapper to be used by the FormBuilder.
+  config.default_wrapper = :default
+
+  # Define the way to render check boxes / radio buttons with labels.
+  # Defaults to :nested for bootstrap config.
+  #   inline: input + label
+  #   nested: label > input
+  config.boolean_style = :nested
+
+  # Default class for buttons
+  config.button_class = 'btn'
+
+  # Method used to tidy up errors. Specify any Rails Array method.
+  # :first lists the first message for each field.
+  # Use :to_sentence to list all errors for each field.
+  # config.error_method = :first
+
+  # Default tag used for error notification helper.
+  config.error_notification_tag = :div
+
+  # CSS class to add for error notification helper.
+  config.error_notification_class = 'error_notification'
+
+  # ID to add for error notification helper.
+  # config.error_notification_id = nil
+
+  # Series of attempts to detect a default label method for collection.
+  # config.collection_label_methods = [ :to_label, :name, :title, :to_s ]
+
+  # Series of attempts to detect a default value method for collection.
+  # config.collection_value_methods = [ :id, :to_s ]
+
+  # You can wrap a collection of radio/check boxes in a pre-defined tag, defaulting to none.
+  # config.collection_wrapper_tag = nil
+
+  # You can define the class to use on all collection wrappers. Defaulting to none.
+  # config.collection_wrapper_class = nil
+
+  # You can wrap each item in a collection of radio/check boxes with a tag,
+  # defaulting to :span.
+  # config.item_wrapper_tag = :span
+
+  # You can define a class to use in all item wrappers. Defaulting to none.
+  # config.item_wrapper_class = nil
+
+  # How the label text should be generated altogether with the required text.
+  # config.label_text = lambda { |label, required, explicit_label| "#{required} #{label}" }
+
+  # You can define the class to use on all labels. Default is nil.
+  # config.label_class = nil
+
+  # You can define the default class to be used on forms. Can be overriden
+  # with `html: { :class }`. Defaulting to none.
+  # config.default_form_class = nil
+
+  # You can define which elements should obtain additional classes
+  # config.generate_additional_classes_for = [:wrapper, :label, :input]
+
+  # Whether attributes are required by default (or not). Default is true.
+  # config.required_by_default = true
+
+  # Tell browsers whether to use the native HTML5 validations (novalidate form option).
+  # These validations are enabled in SimpleForm's internal config but disabled by default
+  # in this configuration, which is recommended due to some quirks from different browsers.
+  # To stop SimpleForm from generating the novalidate option, enabling the HTML5 validations,
+  # change this configuration to true.
+  config.browser_validations = false
+
+  # Collection of methods to detect if a file type was given.
+  # config.file_methods = [ :mounted_as, :file?, :public_filename, :attached? ]
+
+  # Custom mappings for input types. This should be a hash containing a regexp
+  # to match as key, and the input type that will be used when the field name
+  # matches the regexp as value.
+  # config.input_mappings = { /count/ => :integer }
+
+  # Custom wrappers for input types. This should be a hash containing an input
+  # type as key and the wrapper that will be used for all inputs with specified type.
+  # config.wrapper_mappings = { string: :prepend }
+
+  # Namespaces where SimpleForm should look for custom input classes that
+  # override default inputs.
+  # config.custom_inputs_namespaces << "CustomInputs"
+
+  # Default priority for time_zone inputs.
+  # config.time_zone_priority = nil
+
+  # Default priority for country inputs.
+  # config.country_priority = nil
+
+  # When false, do not use translations for labels.
+  # config.translate_labels = true
+
+  # Automatically discover new inputs in Rails' autoload path.
+  # config.inputs_discovery = true
+
+  # Cache SimpleForm inputs discovery
+  # config.cache_discovery = !Rails.env.development?
+
+  # Default class for inputs
+  # config.input_class = nil
+
+  # Define the default class of the input wrapper of the boolean input.
+  config.boolean_label_class = 'checkbox'
+
+  # Defines if the default input wrapper class should be included in radio
+  # collection wrappers.
+  # config.include_default_input_wrapper_class = true
+
+  # Defines which i18n scope will be used in Simple Form.
+  # config.i18n_scope = 'simple_form'
+
+  # Defines validation classes to the input_field. By default it's nil.
+  # config.input_field_valid_class = 'is-valid'
+  # config.input_field_error_class = 'is-invalid'
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
+  resources :interviews
 
   root 'users#index'
   get 'users/index'

--- a/db/migrate/20180710063510_create_interviews.rb
+++ b/db/migrate/20180710063510_create_interviews.rb
@@ -3,7 +3,8 @@ class CreateInterviews < ActiveRecord::Migration[5.1]
     create_table :interviews do |t|
       t.datetime :interview_date
       t.integer :approval
-      t.references :user, foreign_key: true
+      t.string :user_id
+      t.references :user, foreign_key: true, type: :integer
 
       t.timestamps
     end

--- a/db/migrate/20180710063510_create_interviews.rb
+++ b/db/migrate/20180710063510_create_interviews.rb
@@ -3,8 +3,10 @@ class CreateInterviews < ActiveRecord::Migration[5.1]
     create_table :interviews do |t|
       t.datetime :interview_date
       t.integer :approval
+      t.references :user, foreign_key: true
 
       t.timestamps
     end
+    add_index :interviews, [:user_id, :interview_date, :approval]
   end
 end

--- a/db/migrate/20180710063510_create_interviews.rb
+++ b/db/migrate/20180710063510_create_interviews.rb
@@ -2,7 +2,7 @@ class CreateInterviews < ActiveRecord::Migration[5.1]
   def change
     create_table :interviews do |t|
       t.datetime :interview_date
-      t.integer :approval
+      t.string :approval, default: "保留"
       t.string :user_id
       t.references :user, foreign_key: true, type: :integer
 

--- a/db/migrate/20180710063510_create_interviews.rb
+++ b/db/migrate/20180710063510_create_interviews.rb
@@ -1,0 +1,10 @@
+class CreateInterviews < ActiveRecord::Migration[5.1]
+  def change
+    create_table :interviews do |t|
+      t.datetime :interview_date
+      t.integer :approval
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180624144707) do
+ActiveRecord::Schema.define(version: 20180710063510) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "interviews", force: :cascade do |t|
+    t.datetime "interview_date"
+    t.integer "approval"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -18,8 +18,11 @@ ActiveRecord::Schema.define(version: 20180710063510) do
   create_table "interviews", force: :cascade do |t|
     t.datetime "interview_date"
     t.integer "approval"
+    t.integer "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["user_id", "interview_date", "approval"], name: "index_interviews_on_user_id_and_interview_date_and_approval"
+    t.index ["user_id"], name: "index_interviews_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -43,4 +46,5 @@ ActiveRecord::Schema.define(version: 20180710063510) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "interviews", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -17,7 +17,7 @@ ActiveRecord::Schema.define(version: 20180710063510) do
 
   create_table "interviews", force: :cascade do |t|
     t.datetime "interview_date"
-    t.integer "approval"
+    t.string "approval", default: "保留"
     t.integer "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
やりたかったこと
---


- 面接日程の表示・登録
- 面接日程の編集・削除

やったこと
----

- Interviewモデルの作成
- 自分の面接一覧の表示
- 面接日程の登録・編集フォーム追加
- 面接日程の削除機能追加


動作確認方法
---

- [ ] ログインする
- [ ] 自分の面接一覧ページにいく
- [ ] 新規面接作成ページにいく
- [ ] 面接日程を登録
- [ ] 自分の面接一覧ページで登録した面接日程の編集・削除

その他
---

- data-confirm-modalを導入して面接日程の削除時の確認ダイアログを見やすくしました。
- 面接日程の表示が読みづらかったのでstrftimeで表示形式を指定しました。
